### PR TITLE
Arrow binding with 1 argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,12 @@ issues): `$ npm install https://github.com/mozilla/sweet.js.git`
 We are working on a [grunt
 task](https://github.com/jlongster/grunt-sweet.js) to make this
 easier.
+
+## Contributing
+
+To run the tests:
+
+```bash
+npm install
+make
+```

--- a/index.sjs
+++ b/index.sjs
@@ -217,7 +217,7 @@ macro => {
   rule infix { $param:ident | $guard:expr } => {
     function($param) {
       return $guard;
-    }
+    }.bind(this)
   }
 }
 

--- a/macros/fat-arrow.sjs
+++ b/macros/fat-arrow.sjs
@@ -12,7 +12,7 @@ macro => {
   rule infix { $param:ident | $guard:expr } => {
     function($param) {
       return $guard;
-    }
+    }.bind(this)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-contrib-concat": "~0.3.0"
+    "grunt-contrib-concat": "~0.3.0",
+    "sweet.js": "~0.5.0",
+    "grunt-sweet.js": "~0.1.4",
+    "expect.js": "~0.3.1"
   },
-  "tags": ["sweet-macros"]
+  "tags": [
+    "sweet-macros"
+  ]
 }

--- a/tests/fat-arrow.sjs
+++ b/tests/fat-arrow.sjs
@@ -27,15 +27,39 @@ describe('fat arrow', function() {
         expect(squared[2]).to.be(undefined);
     });
 
-    it('should bind this correctly', function() {
+    it('should bind this for infix 0 arguments', function() {
         var obj = {
             id: 1,
-            init: function() {
-                var id = () => this.id;
-                return id();
+            getter: function() {
+                var f = () => this.id;
+                return f();
             }
         };
-        expect(obj.init()).to.be(1);
+        expect(obj.getter()).to.be(1);
+    });
+
+    it('should bind this for infix 1 arguments', function() {
+        var obj = {
+            id: 1,
+            adder: function(x) {
+                var f = x => this.id + x;
+                return f(x)
+            }
+        };
+        expect(obj.adder(5)).to.be(6);
+    });
+
+    it('should bind this for block syntax', function() {
+        var obj = {
+            id: 1,
+            subtractor: function(x) {
+                var f = (x) => {
+                    return this.id - x;
+                }
+                return f(x)
+            }
+        };
+        expect(obj.subtractor(5)).to.be(-4);
     });
 
     it('should implicitly return object', function() {


### PR DESCRIPTION
All arrow functions bind this, even with only one argument:

`x => x + this.y` needs to compile to:

``` js
function(x) {
  return x + this.y;
}.bind(this);
```

This fixes that, and even has tests!
