### PR TITLE
[BUGFIX] Call parent constructor with derived arguments if no derived constructor is provided

### DIFF
--- a/macros/class.sjs
+++ b/macros/class.sjs
@@ -156,7 +156,7 @@ let class = macro {
     } => {
         class_constructor $typename $extends ... {
             constructor() {
-                Object.getPrototypeOf($typename.prototype).constructor.call(this);
+                Object.getPrototypeOf($typename.prototype).constructor.apply(this, arguments);
             }
             $methods ...
         }


### PR DESCRIPTION
Right now, the parent class constructors aren't being called with the callee's arguments if no constructor is provided in the derived.

``` javascript
class Person {
  constructor(name) {
    this.name = name;
  }

  say(msg) {
    console.log(this.name + " says: " + msg);
  }
}

class Bob extends Person {

}

var bob = new Bob("Bob");
bob.say("Macros are sweet!");
// Currently logs "undefined says: Macros are sweet!"
```

http://people.mozilla.org/~jorendorff/es6-draft.html#sec-class-definitions#sec-runtime-semantics-classdefinitionevaluation

![image](https://cloud.githubusercontent.com/assets/762949/3062082/c139f1cc-e215-11e3-8135-7b29846eed34.png)
