### PR TITLE
Add a failing test for handling `arguments` correctly.

### DIFF
--- a/tests/fat-arrow.sjs
+++ b/tests/fat-arrow.sjs
@@ -66,4 +66,15 @@ describe('fat arrow', function() {
         var obj = id => ({ id: id });
         expect(obj(1)).to.eql({id: 1});
     });
+
+    it('should interpret `arguments` as belonging to containing function', function() {
+        var obj = {
+            id: 1,
+            subtractor: function() {
+                var f = () => this.id - arguments[0];
+                return f();
+            }
+        };
+        expect(obj.subtractor(5)).to.be(-4);
+    });
 });


### PR DESCRIPTION
Per the [relevant section of the ES6 spec](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-arrow-function-definitions-runtime-semantics-evaluation), `arguments` inside an arrow function refers to the `arguments` in the lexically enclosing function.

I tried to fix this using a `case infix` macro, but I don't understand it well enough to know exactly how to start.
