### PR TITLE
Add module support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,6 +7,7 @@ module.exports = function(grunt) {
                       'macros/class.sjs',
                       'macros/fat-arrow.sjs',
                       'macros/import.sjs',
+                      'macros/export.sjs',
                       // destructure must come last, so that `var` in
                       // any case macros is not overriden (those have
                       // special syntax)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
                 src: ['macros/util.sjs',
                       'macros/class.sjs',
                       'macros/fat-arrow.sjs',
+                      'macros/import.sjs',
                       // destructure must come last, so that `var` in
                       // any case macros is not overriden (those have
                       // special syntax)

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Currently implemented:
 * destructuring (including elision and rest)
 * classes
 * fat arrow functions
+* (limited) [module](http://jsmodules.io) support (plain `export thing;` is not supported, `export { thing };` and `export default thing;` work fine) -- compiles to CommonJS (`require` and `module.exports`)
 
 TODO:
 
 * rest and default arguments
 * spread operator for applying arguments
 * possibly limited `for of` support
-* possibly limited module support
 
 ## Using
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Currently implemented:
 * destructuring (including elision and rest)
 * classes
 * fat arrow functions
-* (limited) [module](http://jsmodules.io) support (plain `export thing;` is not supported, `export { thing };` and `export default thing;` work fine) -- compiles to CommonJS (`require` and `module.exports`)
+* (limited) [module](http://jsmodules.io) support
 
 TODO:
 
@@ -33,6 +33,23 @@ $ sjs -m es6-macros file.js
 
 If you pass `-c` to sjs along with `-o output.js`, it will generate a
 sourcemap so you get good debugging too!
+
+## Examples
+
+```js
+import { writeFile } from 'fs'; // var fs = require('fs'); writeFile = fs.writeFile
+import * as moment from 'moment'; // var moment = require('moment')
+
+function writeTime(filename) {
+  writeFile(filename, moment().format('hh:mm:ss'), () => console.log('Done'))
+}
+
+// export writeTime; // single exports don't work because Sweet.js itself uses `export`
+export default writeTime;
+export { writeTime };
+
+export var something = 'hello world'; // short form works with vars, functions and classes
+```
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -283,24 +283,21 @@ macro import {
   case {
     $import_name * as $what:ident from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{var $what = $require($where)}
   }
 
   case {
     $import_name $what:ident from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{var $what = $require($where)['default']}
   }
 
   case {
     $import_name { $($what:alias_pair) (,) ... } from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       var __dep = $require($where);
       $(var $what$to = __dep.$what$from) (;) ...
@@ -310,8 +307,7 @@ macro import {
   case {
     $import_name $default:ident, { $($what:alias_pair) (,) ... } from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       var __dep = $require($where);
       var $default = __dep['default'];
@@ -322,8 +318,7 @@ macro import {
   case {
     $import_name $what:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       $require($what);
     }
@@ -349,24 +344,21 @@ let export = macro {
   case {
     $export_name { $($what:ident) (,) ... }
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{$($module.exports.$what = $what) (;) ...}
   }
 
   case {
     $export_name default $what:ident
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{$module.exports['default'] = $what}
   }
 
   case {
     $export_name var $name:ident = $def:expr
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       var $name = $def;
       $module.exports.$name = $name
@@ -376,8 +368,7 @@ let export = macro {
   case {
     $export_name default var $name:ident = $def:expr
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       var $name = $def;
       $module.exports['default'] = $name
@@ -387,8 +378,7 @@ let export = macro {
   case {
     $export_name function $name:ident $params $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       function $name $params $body
       $module.exports.$name = $name;
@@ -398,8 +388,7 @@ let export = macro {
   case {
     $export_name default function $name:ident $params $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       function $name $params $body
       $module.exports['default'] = $name;
@@ -409,8 +398,7 @@ let export = macro {
   case {
     $export_name class $name:ident $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       class $name $body
       $module.exports.$name = $name;
@@ -420,8 +408,7 @@ let export = macro {
   case {
     $export_name default class $name:ident $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       class $name $body
       $module.exports['default'] = $name;

--- a/index.js
+++ b/index.js
@@ -406,6 +406,28 @@ let export = macro {
     }
   }
 
+  case {
+    $export_name class $name:ident $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      class $name $body
+      $module.exports.$name = $name;
+    }
+  }
+
+  case {
+    $export_name default class $name:ident $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      class $name $body
+      $module.exports['default'] = $name;
+    }
+  }
+
   case { _ $macro_name; } => { return #{export $macro_name;} }
 }
 

--- a/index.js
+++ b/index.js
@@ -332,6 +332,85 @@ macro import {
 
 export import;
 
+let export = macro {
+  // https://github.com/mozilla/sweet.js/issues/288
+  case { $export export ; } => { return #{export $export;} }
+
+  // Unfortunately, sweet.js's use of `export` makes the simple single-ident form impossible (?) to implement
+  //
+  // case {
+  //   $export_name $what:ident
+  // } => {
+  //   var module = makeIdent("module", #{$export_name});
+  //   letstx $module = [module];
+  //   return #{$module.exports.$what = $what}
+  // }
+
+  case {
+    $export_name { $($what:ident) (,) ... }
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{$($module.exports.$what = $what) (;) ...}
+  }
+
+  case {
+    $export_name default $what:ident
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{$module.exports['default'] = $what}
+  }
+
+  case {
+    $export_name var $name:ident = $def:expr
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      var $name = $def;
+      $module.exports.$name = $name
+    }
+  }
+
+  case {
+    $export_name default var $name:ident = $def:expr
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      var $name = $def;
+      $module.exports['default'] = $name
+    }
+  }
+
+  case {
+    $export_name function $name:ident $params $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      function $name $params $body
+      $module.exports.$name = $name;
+    }
+  }
+
+  case {
+    $export_name default function $name:ident $params $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      function $name $params $body
+      $module.exports['default'] = $name;
+    }
+  }
+
+  case { _ $macro_name; } => { return #{export $macro_name;} }
+}
+
+export export;
+
 macro destructor {
   rule { [ $arr:arr_destructor (,) ... ] } => { (arr $arr ...) }
   rule { { $obj:obj_destructor (,) ... } } => { (obj $obj ...) }

--- a/macros/export.sjs
+++ b/macros/export.sjs
@@ -15,24 +15,21 @@ let export = macro {
   case {
     $export_name { $($what:ident) (,) ... }
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{$($module.exports.$what = $what) (;) ...}
   }
 
   case {
     $export_name default $what:ident
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{$module.exports['default'] = $what}
   }
 
   case {
     $export_name var $name:ident = $def:expr
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       var $name = $def;
       $module.exports.$name = $name
@@ -42,8 +39,7 @@ let export = macro {
   case {
     $export_name default var $name:ident = $def:expr
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       var $name = $def;
       $module.exports['default'] = $name
@@ -53,8 +49,7 @@ let export = macro {
   case {
     $export_name function $name:ident $params $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       function $name $params $body
       $module.exports.$name = $name;
@@ -64,8 +59,7 @@ let export = macro {
   case {
     $export_name default function $name:ident $params $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       function $name $params $body
       $module.exports['default'] = $name;
@@ -75,8 +69,7 @@ let export = macro {
   case {
     $export_name class $name:ident $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       class $name $body
       $module.exports.$name = $name;
@@ -86,8 +79,7 @@ let export = macro {
   case {
     $export_name default class $name:ident $body
   } => {
-    var module = makeIdent("module", #{$export_name});
-    letstx $module = [module];
+    letstx $module = [makeIdent("module", #{$export_name})];
     return #{
       class $name $body
       $module.exports['default'] = $name;

--- a/macros/export.sjs
+++ b/macros/export.sjs
@@ -72,6 +72,28 @@ let export = macro {
     }
   }
 
+  case {
+    $export_name class $name:ident $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      class $name $body
+      $module.exports.$name = $name;
+    }
+  }
+
+  case {
+    $export_name default class $name:ident $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      class $name $body
+      $module.exports['default'] = $name;
+    }
+  }
+
   case { _ $macro_name; } => { return #{export $macro_name;} }
 }
 

--- a/macros/export.sjs
+++ b/macros/export.sjs
@@ -1,0 +1,78 @@
+let export = macro {
+  // https://github.com/mozilla/sweet.js/issues/288
+  case { $export export ; } => { return #{export $export;} }
+
+  // Unfortunately, sweet.js's use of `export` makes the simple single-ident form impossible (?) to implement
+  //
+  // case {
+  //   $export_name $what:ident
+  // } => {
+  //   var module = makeIdent("module", #{$export_name});
+  //   letstx $module = [module];
+  //   return #{$module.exports.$what = $what}
+  // }
+
+  case {
+    $export_name { $($what:ident) (,) ... }
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{$($module.exports.$what = $what) (;) ...}
+  }
+
+  case {
+    $export_name default $what:ident
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{$module.exports['default'] = $what}
+  }
+
+  case {
+    $export_name var $name:ident = $def:expr
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      var $name = $def;
+      $module.exports.$name = $name
+    }
+  }
+
+  case {
+    $export_name default var $name:ident = $def:expr
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      var $name = $def;
+      $module.exports['default'] = $name
+    }
+  }
+
+  case {
+    $export_name function $name:ident $params $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      function $name $params $body
+      $module.exports.$name = $name;
+    }
+  }
+
+  case {
+    $export_name default function $name:ident $params $body
+  } => {
+    var module = makeIdent("module", #{$export_name});
+    letstx $module = [module];
+    return #{
+      function $name $params $body
+      $module.exports['default'] = $name;
+    }
+  }
+
+  case { _ $macro_name; } => { return #{export $macro_name;} }
+}
+
+export export;

--- a/macros/import.sjs
+++ b/macros/import.sjs
@@ -12,24 +12,21 @@ macro import {
   case {
     $import_name * as $what:ident from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{var $what = $require($where)}
   }
 
   case {
     $import_name $what:ident from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{var $what = $require($where)['default']}
   }
 
   case {
     $import_name { $($what:alias_pair) (,) ... } from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       var __dep = $require($where);
       $(var $what$to = __dep.$what$from) (;) ...
@@ -39,8 +36,7 @@ macro import {
   case {
     $import_name $default:ident, { $($what:alias_pair) (,) ... } from $where:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       var __dep = $require($where);
       var $default = __dep['default'];
@@ -51,8 +47,7 @@ macro import {
   case {
     $import_name $what:expr
   } => {
-    var require = makeIdent("require", #{$import_name});
-    letstx $require = [require];
+    letstx $require = [makeIdent("require", #{$import_name})];
     return #{
       $require($what);
     }

--- a/macros/import.sjs
+++ b/macros/import.sjs
@@ -1,0 +1,62 @@
+macroclass alias_pair {
+  pattern {
+    rule { $from:ident as $to:ident }
+  }
+  pattern { 
+    rule { $from:ident }
+    with $to = #{ $from };
+  }
+}
+
+macro import {
+  case {
+    $import_name * as $what:ident from $where:expr
+  } => {
+    var require = makeIdent("require", #{$import_name});
+    letstx $require = [require];
+    return #{var $what = $require($where)}
+  }
+
+  case {
+    $import_name $what:ident from $where:expr
+  } => {
+    var require = makeIdent("require", #{$import_name});
+    letstx $require = [require];
+    return #{var $what = $require($where)['default']}
+  }
+
+  case {
+    $import_name { $($what:alias_pair) (,) ... } from $where:expr
+  } => {
+    var require = makeIdent("require", #{$import_name});
+    letstx $require = [require];
+    return #{
+      var __dep = $require($where);
+      $(var $what$to = __dep.$what$from) (;) ...
+    }
+  }
+
+  case {
+    $import_name $default:ident, { $($what:alias_pair) (,) ... } from $where:expr
+  } => {
+    var require = makeIdent("require", #{$import_name});
+    letstx $require = [require];
+    return #{
+      var __dep = $require($where);
+      var $default = __dep['default'];
+      $(var $what$to = __dep.$what$from) (;) ...
+    }
+  }
+
+  case {
+    $import_name $what:expr
+  } => {
+    var require = makeIdent("require", #{$import_name});
+    letstx $require = [require];
+    return #{
+      $require($what);
+    }
+  }
+}
+
+export import;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-concat": "~0.3.0",
-    "sweet.js": "~0.5.0",
+    "sweet.js": "~0.6.0",
     "grunt-sweet.js": "~0.1.4",
     "expect.js": "~0.3.1"
   },

--- a/tests/export.sjs
+++ b/tests/export.sjs
@@ -47,4 +47,18 @@ describe('export', function() {
     expect(module.exports['default']()).to.eql('MAGIC');
   });
 
+  it('should export classes (short form)', function() {
+    var module = {exports: {}};
+    export class ThingDoer { doSomething() { return 'MAGIC'; } }
+    expect(new ThingDoer().doSomething()).to.eql('MAGIC');
+    expect(new module.exports.ThingDoer().doSomething()).to.eql('MAGIC');
+  });
+
+  it('should export classes as default (short form)', function() {
+    var module = {exports: {}};
+    export default class ThingDoer { doSomething() { return 'MAGIC'; } }
+    expect(new ThingDoer().doSomething()).to.eql('MAGIC');
+    expect(new module.exports['default']().doSomething()).to.eql('MAGIC');
+  });
+
 });

--- a/tests/export.sjs
+++ b/tests/export.sjs
@@ -1,0 +1,50 @@
+"use strict";
+var expect = require('expect.js');
+
+describe('export', function() {
+
+  it('should export identifiers', function() {
+    var module = {exports: {}};
+    var something = 'MAGIC';
+    var something_else = 'NOT MAGIC';
+    export { something, something_else };
+    expect(module.exports.something).to.eql('MAGIC');
+    expect(module.exports.something_else).to.eql('NOT MAGIC');
+  });
+
+  it('should export an identifier as default', function() {
+    var module = {exports: {}};
+    var something = 'MAGIC';
+    export default something;
+    expect(module.exports['default']).to.eql('MAGIC');
+  });
+
+  it('should export vars (short form)', function() {
+    var module = {exports: {}};
+    export var something = 'MAGIC';
+    expect(something).to.eql('MAGIC');
+    expect(module.exports.something).to.eql('MAGIC');
+  });
+
+  it('should export vars as default (short form)', function() {
+    var module = {exports: {}};
+    export default var something = 'MAGIC';
+    expect(something).to.eql('MAGIC');
+    expect(module.exports['default']).to.eql('MAGIC');
+  });
+
+  it('should export functions (short form)', function() {
+    var module = {exports: {}};
+    export function doSomething() { return 'MAGIC'; }
+    expect(doSomething()).to.eql('MAGIC');
+    expect(module.exports.doSomething()).to.eql('MAGIC');
+  });
+
+  it('should export functions as default (short form)', function() {
+    var module = {exports: {}};
+    export default function doSomething() { return 'MAGIC'; }
+    expect(doSomething()).to.eql('MAGIC');
+    expect(module.exports['default']()).to.eql('MAGIC');
+  });
+
+});

--- a/tests/import.sjs
+++ b/tests/import.sjs
@@ -1,0 +1,54 @@
+"use strict";
+var expect = require('expect.js');
+
+describe('import', function() {
+  it('should import whole modules', function() {
+    var require = function(arg) {
+      expect(arg).to.eql('modulename');
+      return 'MAGIC';
+    }
+    import * as $ from 'modulename';
+    expect($).to.eql('MAGIC');
+  });
+
+  it('should import default exports', function() {
+    var require = function(arg) {
+      expect(arg).to.eql('modulename');
+      return {'default': 'MAGIC'};
+    }
+    import $ from 'modulename';
+    expect($).to.eql('MAGIC');
+  });
+
+  it('should import multiple exports with renaming', function() {
+    var require = function(arg) {
+      expect(arg).to.eql('modulename');
+      return {'one': 1, 'two': 2};
+    }
+    import { one as first, two } from 'modulename';
+    expect(first).to.eql(1);
+    expect(two).to.eql(2);
+  });
+
+  it('should import multiple exports and the default', function() {
+    var require = function(arg) {
+      expect(arg).to.eql('modulename');
+      return {'default': 0, 'one': 1, 'two': 2};
+    }
+    import dflt, { one as first, two } from 'modulename';
+    expect(dflt).to.eql(0);
+    expect(first).to.eql(1);
+    expect(two).to.eql(2);
+  });
+
+  it('should import as nothing for side effects', function() {
+    var some_outside_thing = 0;
+    var require = function(arg) {
+      expect(arg).to.eql('modulename');
+      some_outside_thing = 1;
+    }
+    import 'modulename';
+    expect(some_outside_thing).to.eql(1);
+  });
+
+});


### PR DESCRIPTION
This patch adds support for [latest ES6 module syntax](http://jsmodules.io), which is compiled to CommonJS.
It uses the same convention for `default` as [Square's es6-module-transpiler](https://github.com/square/es6-module-transpiler), ie. `module.exports['default']` / `require('something')['default']`.
